### PR TITLE
Feature/kakao login logic

### DIFF
--- a/presentation/src/main/AndroidManifest.xml
+++ b/presentation/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="team.sungbinland.sseukssak">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
     <uses-permission android:name="android.permission.INTERNET" />

--- a/presentation/src/main/kotlin/team/sungbinland/sseukssak/activity/login/LoginActivity.kt
+++ b/presentation/src/main/kotlin/team/sungbinland/sseukssak/activity/login/LoginActivity.kt
@@ -5,26 +5,19 @@
  * Please see: https://github.com/sungbinland/sseukssak/blob/main/LICENSE.
  */
 
-/*
- * SseukSsak © 2022 Team Sungbinland. all rights reserved.
- * SseukSsak license is under the MIT.
- *
- * Please see: https://github.com/sungbinland/sseukssak/blob/main/LICENSE.
- */
-
 package team.sungbinland.sseukssak.activity.login
 
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.viewModels
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
-import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.flowWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import com.kakao.sdk.auth.model.OAuthToken
 import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.user.UserApiClient
+import io.github.jisungbin.logeukes.LoggerType
+import io.github.jisungbin.logeukes.logeukes
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import team.sungbinland.sseukssak.R
@@ -44,16 +37,16 @@ class LoginActivity : BaseActivity<ActivityLoginBinding, LoginViewModel>(R.layou
 
         vm.checkLoginState { state ->
             when (state) {
-                LoginState.LOG_OUT -> {}
-                LoginState.LOGGED_IN -> {
+                LoginState.LogOut -> {}
+                LoginState.LoggedIn -> {
                     // TODO 메인 화면으로 이동 혹은 로그아웃 처리
-                    Log.i(TAG, "이미 로그인 된 상태입니다")
+                    logeukes(type = LoggerType.I) { "이미 로그인 된 상태입니다" }
                 }
             }
         }
 
         vm.eventFlow
-            .flowWithLifecycle(this.lifecycle, Lifecycle.State.STARTED)
+            .flowWithLifecycle(this.lifecycle)
             .onEach { event -> handleEvent(event) }
             .launchIn(lifecycleScope)
     }
@@ -66,9 +59,9 @@ class LoginActivity : BaseActivity<ActivityLoginBinding, LoginViewModel>(R.layou
     private fun kakaoLogin() {
         val callback: (OAuthToken?, Throwable?) -> Unit = { token, error ->
             if (error != null) {
-                Log.e(TAG, "카카오계정으로 로그인 실패", error)
+                logeukes(type = LoggerType.E) { "카카오계정으로 로그인 실패\n$error" }
             } else if (token != null) {
-                Log.i(TAG, "카카오계정으로 로그인 성공 ${token.accessToken}")
+                logeukes(type = LoggerType.I) { "카카오계정으로 로그인 성공 ${token.accessToken}" }
                 loginSuccess()
                 // TODO 메인 화면으로 이동
             }
@@ -81,7 +74,7 @@ class LoginActivity : BaseActivity<ActivityLoginBinding, LoginViewModel>(R.layou
     }
 
     private fun skipLogin() {
-        Log.d("LoginActivity", "로그인 건너 뛰기")
+        logeukes { "로그인 건너 뛰기" }
     }
 
     private fun loginWithKakaoTalkApp(callback: (OAuthToken?, Throwable?) -> Unit) {
@@ -90,12 +83,12 @@ class LoginActivity : BaseActivity<ActivityLoginBinding, LoginViewModel>(R.layou
                 if (error is ClientError && error.reason == ClientErrorCause.Cancelled) {
                     return@loginWithKakaoTalk
                 }
-                Log.e(TAG, "loginWithKakaoTalkApp: error", error)
+                logeukes(type = LoggerType.E) { "loginWithKakaoTalkApp: error: $error" }
                 loginWithKakaoAccount(callback)
             } else if (token != null) {
                 // TODO 메인 화면으로 이동
                 loginSuccess()
-                Log.i(TAG, "로그인 성공 ${token.accessToken}")
+                logeukes(type = LoggerType.I) { "로그인 성공 ${token.accessToken}" }
             }
         }
     }
@@ -112,9 +105,5 @@ class LoginActivity : BaseActivity<ActivityLoginBinding, LoginViewModel>(R.layou
                 toast("${user.kakaoAccount?.profile?.nickname}님 환영합니다!")
             }
         }
-    }
-
-    companion object {
-        const val TAG = "LoginActivity"
     }
 }

--- a/presentation/src/main/kotlin/team/sungbinland/sseukssak/activity/login/LoginRepository.kt
+++ b/presentation/src/main/kotlin/team/sungbinland/sseukssak/activity/login/LoginRepository.kt
@@ -1,0 +1,27 @@
+/*
+ * SseukSsak © 2022 Team Sungbinland. all rights reserved.
+ * SseukSsak license is under the MIT.
+ *
+ * Please see: https://github.com/sungbinland/sseukssak/blob/main/LICENSE.
+ */
+
+package team.sungbinland.sseukssak.activity.login
+
+import android.content.SharedPreferences
+import team.sungbinland.sseukssak.util.extensions.get
+import team.sungbinland.sseukssak.util.extensions.set
+import javax.inject.Inject
+
+class LoginRepository @Inject constructor(private val preference: SharedPreferences) {
+    fun saveUserId(userId: Long) {
+        preference[USER_ID] = userId
+    }
+
+    fun checkLoggedIn(): Boolean {
+        return preference[USER_ID, 0L] != 0L
+    }
+
+    companion object {
+        private const val USER_ID = "user-id"
+    }
+}

--- a/presentation/src/main/kotlin/team/sungbinland/sseukssak/activity/login/LoginState.kt
+++ b/presentation/src/main/kotlin/team/sungbinland/sseukssak/activity/login/LoginState.kt
@@ -8,5 +8,5 @@
 package team.sungbinland.sseukssak.activity.login
 
 enum class LoginState {
-    LOGGED_IN, LOG_OUT
+    LoggedIn, LogOut
 }

--- a/presentation/src/main/kotlin/team/sungbinland/sseukssak/activity/login/LoginViewModel.kt
+++ b/presentation/src/main/kotlin/team/sungbinland/sseukssak/activity/login/LoginViewModel.kt
@@ -5,13 +5,6 @@
  * Please see: https://github.com/sungbinland/sseukssak/blob/main/LICENSE.
  */
 
-/*
- * SseukSsak © 2022 Team Sungbinland. all rights reserved.
- * SseukSsak license is under the MIT.
- *
- * Please see: https://github.com/sungbinland/sseukssak/blob/main/LICENSE.
- */
-
 package team.sungbinland.sseukssak.activity.login
 
 import androidx.lifecycle.viewModelScope
@@ -30,11 +23,11 @@ class LoginViewModel : BaseViewModel() {
         if (AuthApiClient.instance.hasToken()) {
             UserApiClient.instance.accessTokenInfo { tokenInfo, error ->
                 if (error == null && tokenInfo != null) {
-                    state(LoginState.LOGGED_IN)
+                    state(LoginState.LoggedIn)
                 }
             }
         } else {
-            state(LoginState.LOG_OUT)
+            state(LoginState.LogOut)
         }
     }
 

--- a/presentation/src/main/kotlin/team/sungbinland/sseukssak/activity/login/LoginViewModel.kt
+++ b/presentation/src/main/kotlin/team/sungbinland/sseukssak/activity/login/LoginViewModel.kt
@@ -8,27 +8,27 @@
 package team.sungbinland.sseukssak.activity.login
 
 import androidx.lifecycle.viewModelScope
-import com.kakao.sdk.auth.AuthApiClient
-import com.kakao.sdk.user.UserApiClient
+import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.launch
 import team.sungbinland.sseukssak.base.BaseViewModel
+import javax.inject.Inject
 
-class LoginViewModel : BaseViewModel() {
+@HiltViewModel
+class LoginViewModel @Inject constructor(private val repository: LoginRepository) : BaseViewModel() {
     private val _eventFlow = MutableSharedFlow<Event>()
     val eventFlow = _eventFlow.asSharedFlow()
 
-    fun checkLoginState(state: (LoginState) -> Unit) {
-        if (AuthApiClient.instance.hasToken()) {
-            UserApiClient.instance.accessTokenInfo { tokenInfo, error ->
-                if (error == null && tokenInfo != null) {
-                    state(LoginState.LoggedIn)
-                }
-            }
+    fun checkLoginState() =
+        if (repository.checkLoggedIn()) {
+            LoginState.LoggedIn
         } else {
-            state(LoginState.LogOut)
+            LoginState.LogOut
         }
+
+    fun saveLoginState(userId: Long) {
+        repository.saveUserId(userId)
     }
 
     fun kakaoLogin() {

--- a/presentation/src/main/kotlin/team/sungbinland/sseukssak/di/common/RepositoryModule.kt
+++ b/presentation/src/main/kotlin/team/sungbinland/sseukssak/di/common/RepositoryModule.kt
@@ -1,0 +1,25 @@
+/*
+ * SseukSsak © 2022 Team Sungbinland. all rights reserved.
+ * SseukSsak license is under the MIT.
+ *
+ * Please see: https://github.com/sungbinland/sseukssak/blob/main/LICENSE.
+ */
+
+package team.sungbinland.sseukssak.di.common
+
+import android.content.SharedPreferences
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import team.sungbinland.sseukssak.activity.login.LoginRepository
+
+@Module
+@InstallIn(SingletonComponent::class)
+object RepositoryModule {
+
+    @Provides
+    fun provideLoginRepository(preference: SharedPreferences): LoginRepository {
+        return LoginRepository(preference)
+    }
+}

--- a/presentation/src/main/kotlin/team/sungbinland/sseukssak/util/extensions/SharedPreferences.kt
+++ b/presentation/src/main/kotlin/team/sungbinland/sseukssak/util/extensions/SharedPreferences.kt
@@ -17,3 +17,7 @@ import androidx.core.content.edit
 operator fun SharedPreferences.get(name: String, default: String? = null) = getString(name, default)
 
 operator fun SharedPreferences.set(name: String, value: String) = edit { putString(name, value) }
+
+operator fun SharedPreferences.get(name: String, default: Long) = getLong(name, default)
+
+operator fun SharedPreferences.set(name: String, value: Long) = edit { putLong(name, value) }

--- a/presentation/src/main/res/drawable/bg_kakao_login_button.xml
+++ b/presentation/src/main/res/drawable/bg_kakao_login_button.xml
@@ -5,10 +5,8 @@
   ~ Please see: https://github.com/sungbinland/sseukssak/blob/main/LICENSE.
   -->
 
-<shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
-
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="rectangle">
     <solid android:color="#FEE500" />
     <corners android:radius="47dp" />
-
-
 </shape>

--- a/presentation/src/main/res/layout/activity_login.xml
+++ b/presentation/src/main/res/layout/activity_login.xml
@@ -5,7 +5,8 @@
   ~ Please see: https://github.com/sungbinland/sseukssak/blob/main/LICENSE.
   -->
 
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
@@ -19,22 +20,23 @@
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 
-        <androidx.appcompat.widget.LinearLayoutCompat
+        <LinearLayout
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="vertical"
             app:layout_constraintBottom_toTopOf="@id/layout_kakao_login_button"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent">
+            app:layout_constraintTop_toTopOf="parent"
+            tools:ignore="UseCompoundDrawables">
 
             <ImageView
                 android:id="@+id/iv_icon"
                 android:layout_width="125dp"
                 android:layout_height="93dp"
+                android:layout_gravity="center"
                 android:contentDescription="@null"
                 android:src="@mipmap/leak_canary_icon"
-                android:layout_gravity="center"
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toTopOf="parent" />
@@ -51,7 +53,7 @@
                 app:layout_constraintStart_toStartOf="parent"
                 app:layout_constraintTop_toBottomOf="@id/iv_icon" />
 
-        </androidx.appcompat.widget.LinearLayoutCompat>
+        </LinearLayout>
 
         <androidx.constraintlayout.widget.ConstraintLayout
             android:id="@+id/layout_kakao_login_button"
@@ -69,8 +71,8 @@
 
             <ImageView
                 android:id="@+id/iv_kakao_symbol"
-                android:layout_width="17dp"
-                android:layout_height="15dp"
+                android:layout_width="16dp"
+                android:layout_height="16dp"
                 android:layout_marginEnd="10dp"
                 android:layout_toStartOf="@id/tv_kakao_login_button"
                 android:contentDescription="@null"
@@ -92,6 +94,7 @@
                 app:layout_constraintEnd_toEndOf="parent"
                 app:layout_constraintStart_toEndOf="@id/iv_kakao_symbol"
                 app:layout_constraintTop_toTopOf="parent" />
+
         </androidx.constraintlayout.widget.ConstraintLayout>
 
         <TextView

--- a/presentation/src/main/res/layout/activity_login.xml
+++ b/presentation/src/main/res/layout/activity_login.xml
@@ -5,9 +5,9 @@
   ~ Please see: https://github.com/sungbinland/sseukssak/blob/main/LICENSE.
   -->
 
-<layout xmlns:tools="http://schemas.android.com/tools"
-    xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools">
 
     <data>
 


### PR DESCRIPTION
## 변경 사항

- 일부 스타일을 변경했습니다.
  - 중복된 라이선스 정보 제거
  - enum class 멤버의 네이밍을 대문자에서 카멜케이스로 변경
  - `AndroidManifest.xml`의 `package` 정보 제거
  - 기타 개행 등 스타일 변경
- 로그인 상태 확인 로직을 변경했습니다
  - kakao API의 `me`에 들어있는 **token** 정보를 저장하고, **token** 값을 가져왔을 때 **0L(DefaultValue)**가 아니라면 로그인 되어있는 상태로 판단합니다. (*추후 로그아웃 기능 구현 시 token 정보를 0L로 바꾸는 로직 필요*)
  - `LoginRepository.kt` 를 추가했고, 이 곳에서 `SharedPreference`를 통해 **token** 값을 저장합니다.
  - `SharedPreference`를 `LoginRepository`에 주입하고, `LoginRepository`를 `LoginViewModel`에 주입하기 위해서 **hilt**를 사용했습니다.
- `Log` 로 되어있는 부분을 `logeukes`로 대체했습니다.

## 결과 사진

UI 변경은 없습니다

### 로그인 전

<img src="https://user-images.githubusercontent.com/44221447/176629645-b3d047f6-6eac-4eb7-a8b2-5fcabc9b3184.png" width="33%" />

### 로그인 후

<img src="https://user-images.githubusercontent.com/44221447/176629600-51fc9bad-1c1e-4e1e-8913-b07c69e77fd3.png" width="33%" />

